### PR TITLE
Fix selection name selection for GM and VN

### DIFF
--- a/addons/main/functions/fnc_getExits.sqf
+++ b/addons/main/functions/fnc_getExits.sqf
@@ -22,7 +22,7 @@ params ["_vehicle"];
 
 // get proxies
 private _sn = _vehicle selectionNames "Memory" select {
-    _x select [0,4] == "pos " && {_x find "dir" == -1}
+    _x select [0,3] == "pos" && {(_x select [3,1]) in [" ", "_"]} && {_x find "dir" == -1}
 };
 if (_sn isEqualTo []) exitWith {};
 

--- a/addons/main/functions/fnc_getExits.sqf
+++ b/addons/main/functions/fnc_getExits.sqf
@@ -22,7 +22,7 @@ params ["_vehicle"];
 
 // get proxies
 private _sn = _vehicle selectionNames "Memory" select {
-    _x select [0,3] == "pos" && {(_x select [3,1]) in [" ", "_"]} && {_x find "dir" == -1}
+    (_x select [0,3] == "pos" && {(_x select [3,1]) in [" ", "_"]} && {_x find "dir" == -1} ) || _x select [count _x - count "_getin_pos"] isEqualTo "_getin_pos"
 };
 if (_sn isEqualTo []) exitWith {};
 


### PR DESCRIPTION
got these very often recently:
```
22:27:06 Error in expression <[{
player == vehicle player
}, {
player attachTo [_this, dwyl_exit_position vect>
22:27:06   Error position: <attachTo [_this, dwyl_exit_position vect>
22:27:06   Error 0 elements provided, 3 expected
22:27:06 File z\dwyl\addons\main\functions\fnc_exit.sqf..., line 33
22:27:06  ➥ Context:     [] L1 ()
    [] L66 ()
    [] L59 ()
    [] L56 (x\cba\addons\common\fnc_waitUntilAndExecute.sqf)
    [] L57 (x\cba\addons\common\fnc_waitUntilAndExecute.sqf)
    [] L42 (z\dwyl\addons\main\functions\fnc_exit.sqf)
```

and it seems GM and VN vehicles use different conventions for selection names