### PR TITLE
Fix signature checking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   hemtt:
     name: HEMTT
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2


### PR DESCRIPTION
Bisign file creation is broken in HEMTT on Linux. This changes building on Windows instead, which fixes signature checking.